### PR TITLE
Replace chromo with jiff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 homepage = "https://crates.io/crates/skedge"
 include = ["**/*.rs", "Cargo.toml"]
 keywords = ["utility", "scheduling"]
-license = "BSD-3-Clause"
+license = "MIT"
 name = "skedge"
 readme = "README.md"
 repository = "https://github.com/deciduously/skedge"
-version = "0.2.1"
+version = "0.3.0"
 rust-version = "1.80"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ license = "BSD-3-Clause"
 name = "skedge"
 readme = "README.md"
 repository = "https://github.com/deciduously/skedge"
-version = "0.2.0"
-rust-version = "1.80.0"
+version = "0.2.1"
+rust-version = "1.80"
 
 [lib]
 crate-type = ["rlib", "cdylib"]
@@ -22,14 +22,14 @@ ffi = []
 
 [dependencies]
 chrono = "0.4"
-libc = { version = "0.2" }
+libc = "0.2"
 rand = "0.8"
 regex = "1.5"
 thiserror = "1.0"
 tracing = "0.1"
 
 [dev-dependencies]
-pretty_assertions = "1.2"
+pretty_assertions = "1"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default = []
 ffi = []
 
 [dependencies]
-chrono = "0.4"
+jiff = "0.1"
 libc = "0.2"
 rand = "0.8"
 regex = "1.5"

--- a/LICENSE
+++ b/LICENSE
@@ -1,29 +1,22 @@
-BSD 3-Clause License
+MIT License
 
-Copyright (c) 2021, Benjamin Lovy
-All rights reserved.
+Copyright (c) 2024 Ben Lovy
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Documentation can be found on [docs.rs](https://docs.rs/skedge).
 This library uses the Builder pattern to define jobs. Instantiate a fresh `Scheduler`, then use the `every()` and `every_single()` functions to begin defining a job. Finalize configuration by calling `Job::run()` to add the new job to the scheduler. The `Scheduler::run_pending()` method is used to fire any jobs that have arrived at their next scheduled run time. Currently, precision can only be specified to the second, no smaller.
 
 ```rust
-use chrono::Local;
+use jiff::Zoned;
 use skedge::{every, Scheduler};
 use std::thread::sleep;
 use std::time::Duration;
 
 fn greet(name: &str) {
-    let now = Local::now().to_rfc2822();
+    let now = Zoned::now();
     println!("Hello {name}, it's {now}!");
 }
 
@@ -29,10 +29,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     every(2)
         .to(8)?
         .seconds()?
-        .until(Local::now() + chrono::Duration::seconds(30))?
+        .until(Zoned::now() + Duration::from_secs(30))?
         .run_one_arg(&mut schedule, greet, "Cool Person")?;
 
-    let now = Local::now();
+    let now = Zoned::now();
     println!("Starting at {now}");
     loop {
         if let Err(e) = schedule.run_pending() {

--- a/README.md
+++ b/README.md
@@ -13,33 +13,33 @@ Documentation can be found on [docs.rs](https://docs.rs/skedge).
 This library uses the Builder pattern to define jobs. Instantiate a fresh `Scheduler`, then use the `every()` and `every_single()` functions to begin defining a job. Finalize configuration by calling `Job::run()` to add the new job to the scheduler. The `Scheduler::run_pending()` method is used to fire any jobs that have arrived at their next scheduled run time. Currently, precision can only be specified to the second, no smaller.
 
 ```rust
-use jiff::Zoned;
+use jiff::{ToSpan, Zoned};
 use skedge::{every, Scheduler};
 use std::thread::sleep;
 use std::time::Duration;
 
 fn greet(name: &str) {
-    let now = Zoned::now();
-    println!("Hello {name}, it's {now}!");
+	let now = Zoned::now();
+	println!("Hello {name}, it's {now}!");
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut schedule = Scheduler::new();
+	let mut schedule = Scheduler::new();
 
-    every(2)
-        .to(8)?
-        .seconds()?
-        .until(Zoned::now() + Duration::from_secs(30))?
-        .run_one_arg(&mut schedule, greet, "Cool Person")?;
+	every(2)
+		.to(8)?
+		.seconds()?
+		.until(Zoned::now().checked_add(30.seconds()).unwrap())?
+		.run_one_arg(&mut schedule, greet, "Cool Person")?;
 
-    let now = Zoned::now();
-    println!("Starting at {now}");
-    loop {
-        if let Err(e) = schedule.run_pending() {
-            eprintln!("Error: {e}");
-        }
-        sleep(Duration::from_secs(1));
-    }
+	let now = Zoned::now();
+	println!("Starting at {now}");
+	loop {
+		if let Err(e) = schedule.run_pending() {
+			eprintln!("Error: {e}");
+		}
+		sleep(Duration::from_secs(1));
+	}
 }
 ```
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,12 +1,12 @@
 // Some more varied usage examples.
 
-use chrono::Local;
+use jiff::{ToSpan, Zoned};
 use skedge::{every, every_single, Scheduler};
 use std::thread::sleep;
 use std::time::Duration;
 
 fn job() {
-	let now = Local::now().to_rfc2822();
+	let now = Zoned::now();
 	println!("Hello, it's {now}!");
 }
 
@@ -41,7 +41,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 	every(2)
 		.to(8)?
 		.seconds()?
-		.until(Local::now() + chrono::Duration::days(5))?
+		.until(Zoned::now().checked_add(5.seconds()).unwrap())?
 		.run_six_args(
 			&mut schedule,
 			flirt,
@@ -53,7 +53,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 			"foraged chanterelle croque monsieur",
 		)?;
 
-	let now = Local::now().to_rfc3339();
+	let now = Zoned::now();
 	println!("Starting at {now}");
 	loop {
 		if let Err(e) = schedule.run_pending() {

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -1,12 +1,12 @@
 // This is the exact code from the README.md example
 
-use chrono::Local;
+use jiff::{ToSpan, Zoned};
 use skedge::{every, Scheduler};
 use std::thread::sleep;
 use std::time::Duration;
 
 fn greet(name: &str) {
-	let now = Local::now().to_rfc2822();
+	let now = Zoned::now();
 	println!("Hello {name}, it's {now}!");
 }
 
@@ -16,10 +16,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 	every(2)
 		.to(8)?
 		.seconds()?
-		.until(Local::now() + chrono::Duration::seconds(30))?
+		.until(Zoned::now().checked_add(30.seconds()).unwrap())?
 		.run_one_arg(&mut schedule, greet, "Cool Person")?;
 
-	let now = Local::now();
+	let now = Zoned::now();
 	println!("Starting at {now}");
 	loop {
 		if let Err(e) = schedule.run_pending() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 //! This module defines the error type and Result alias.
 
 use crate::Unit;
-use chrono::Weekday;
+use jiff::civil::Weekday;
 use thiserror::Error;
 
 #[derive(Debug, PartialEq, Error)]
@@ -17,15 +17,15 @@ pub enum Error {
 	#[error("Invalid unit (valid units are `days`, `hours`, and `minutes`)")]
 	InvalidUnit,
 	#[error("Invalid hour ({0} is not between 0 and 23)")]
-	InvalidHour(u32),
+	InvalidHour(i8),
 	#[error("Invalid time format for daily job (valid format is HH:MM(:SS)?)")]
 	InvalidDailyAtStr,
 	#[error("Invalid time format for hourly job (valid format is (MM)?:SS)")]
 	InvalidHourlyAtStr,
 	#[error("Invalid time format for minutely job (valid format is :SS)")]
 	InvalidMinuteAtStr,
-	#[error("Invalid hms values for NaiveTime ({0},{1},{2})")]
-	InvalidNaiveTime(u32, u32, u32),
+	#[error("Invalid hms values for civil::Time ({0},{1},{2})")]
+	InvalidCivilTime(i8, i8, i8),
 	#[error("Invalid string format for until()")]
 	InvalidUntilStr,
 	#[error("Cannot schedule a job to run until a time in the past")]
@@ -42,9 +42,9 @@ pub enum Error {
 	StartDayError,
 	#[error("{0}")]
 	ParseInt(#[from] std::num::ParseIntError),
-	#[error("Scheduling jobs on {0} is only allowed for weekly jobs.  Using specific days on a job scheduled to run every 2 or more weeks is not supported")]
+	#[error("Scheduling jobs on {0:?} is only allowed for weekly jobs.  Using specific days on a job scheduled to run every 2 or more weeks is not supported")]
 	Weekday(Weekday),
-	#[error("Cannot schedule {0} job, already scheduled for {1}")]
+	#[error("Cannot schedule {0:?} job, already scheduled for {1:?}")]
 	WeekdayCollision(Weekday, Weekday),
 	#[error("Invalid unit without specifying start day")]
 	UnspecifiedStartDay,
@@ -56,13 +56,8 @@ pub(crate) fn unit_error(intended: Unit, existing: Unit) -> Error {
 }
 
 /// Construct a new invalid hour error.
-pub(crate) fn invalid_hour_error(hour: u32) -> Error {
+pub(crate) fn invalid_hour_error(hour: i8) -> Error {
 	Error::InvalidHour(hour)
-}
-
-/// Concstruct a new invalid HMS error.
-pub(crate) fn invalid_hms_error(hour: u32, minute: u32, second: u32) -> Error {
-	Error::InvalidNaiveTime(hour, minute, second)
 }
 
 /// Construct a new Interval error.

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use crate::Unit;
 use jiff::civil::Weekday;
 use thiserror::Error;
 
-#[derive(Debug, PartialEq, Error)]
+#[derive(Debug, Error)]
 pub enum Error {
 	#[error("Tried to reference this job's inner subroutine but failed")]
 	CallableUnreachable,
@@ -24,8 +24,6 @@ pub enum Error {
 	InvalidHourlyAtStr,
 	#[error("Invalid time format for minutely job (valid format is :SS)")]
 	InvalidMinuteAtStr,
-	#[error("Invalid hms values for civil::Time ({0},{1},{2})")]
-	InvalidCivilTime(i8, i8, i8),
 	#[error("Invalid string format for until()")]
 	InvalidUntilStr,
 	#[error("Cannot schedule a job to run until a time in the past")]
@@ -40,6 +38,8 @@ pub enum Error {
 	UnitUnreachable,
 	#[error("Attempted to use a start day for a unit other than `weeks`")]
 	StartDayError,
+	#[error("{0}")]
+	Jiff(#[from] jiff::Error),
 	#[error("{0}")]
 	ParseInt(#[from] std::num::ParseIntError),
 	#[error("Scheduling jobs on {0:?} is only allowed for weekly jobs.  Using specific days on a job scheduled to run every 2 or more weeks is not supported")]

--- a/src/job.rs
+++ b/src/job.rs
@@ -1132,31 +1132,31 @@ mod tests {
 	fn test_reject_weekday_multiple_weeks() {
 		assert_eq!(
             every(2).monday().unwrap_err().to_string(),
-            "Scheduling jobs on Mon is only allowed for weekly jobs.  Using specific days on a job scheduled to run every 2 or more weeks is not supported".to_string()
+            "Scheduling jobs on Monday is only allowed for weekly jobs.  Using specific days on a job scheduled to run every 2 or more weeks is not supported".to_string()
         );
 		assert_eq!(
             every(2).tuesday().unwrap_err().to_string(),
-            "Scheduling jobs on Tue is only allowed for weekly jobs.  Using specific days on a job scheduled to run every 2 or more weeks is not supported".to_string()
+            "Scheduling jobs on Tuesday is only allowed for weekly jobs.  Using specific days on a job scheduled to run every 2 or more weeks is not supported".to_string()
         );
 		assert_eq!(
             every(2).wednesday().unwrap_err().to_string(),
-            "Scheduling jobs on Wed is only allowed for weekly jobs.  Using specific days on a job scheduled to run every 2 or more weeks is not supported".to_string()
+            "Scheduling jobs on Wednesday is only allowed for weekly jobs.  Using specific days on a job scheduled to run every 2 or more weeks is not supported".to_string()
         );
 		assert_eq!(
             every(2).thursday().unwrap_err().to_string(),
-            "Scheduling jobs on Thu is only allowed for weekly jobs.  Using specific days on a job scheduled to run every 2 or more weeks is not supported".to_string()
+            "Scheduling jobs on Thursday is only allowed for weekly jobs.  Using specific days on a job scheduled to run every 2 or more weeks is not supported".to_string()
         );
 		assert_eq!(
             every(2).friday().unwrap_err().to_string(),
-            "Scheduling jobs on Fri is only allowed for weekly jobs.  Using specific days on a job scheduled to run every 2 or more weeks is not supported".to_string()
+            "Scheduling jobs on Friday is only allowed for weekly jobs.  Using specific days on a job scheduled to run every 2 or more weeks is not supported".to_string()
         );
 		assert_eq!(
             every(2).saturday().unwrap_err().to_string(),
-            "Scheduling jobs on Sat is only allowed for weekly jobs.  Using specific days on a job scheduled to run every 2 or more weeks is not supported".to_string()
+            "Scheduling jobs on Saturday is only allowed for weekly jobs.  Using specific days on a job scheduled to run every 2 or more weeks is not supported".to_string()
         );
 		assert_eq!(
             every(2).sunday().unwrap_err().to_string(),
-            "Scheduling jobs on Sun is only allowed for weekly jobs.  Using specific days on a job scheduled to run every 2 or more weeks is not supported".to_string()
+            "Scheduling jobs on Sunday is only allowed for weekly jobs.  Using specific days on a job scheduled to run every 2 or more weeks is not supported".to_string()
         );
 	}
 

--- a/src/job.rs
+++ b/src/job.rs
@@ -244,8 +244,8 @@ impl Job {
 	/// # fn job() {}
 	/// # fn main() -> Result<()> {
 	/// # let mut scheduler = Scheduler::new();
-	/// use chrono::Duration;
-	/// let deadline = chrono::Local::now() + Duration::minutes(10);
+	/// use jiff::{ToSpan, Zoned};
+	/// let deadline = Zoned::now().checked_add(10.minutes())?;
 	/// every_single().minute()?.at(":15")?.until(deadline)?.run(&mut scheduler, job)?;
 	/// # Ok(())
 	/// # }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! Define a work function:
 //! ```rust
 //! fn job() {
-//!     println!("Hello, it's {}!", chrono::Local::now().to_rfc2822());
+//!     println!("Hello, it's {}!", jiff::Zoned::now());
 //! }
 //! ```
 //! You can use up to six arguments:
@@ -18,11 +18,11 @@
 //! Instantiate a `Scheduler` and schedule jobs:
 //! ```rust
 //! # use skedge::{Scheduler, every, every_single};
-//! # use chrono::Local;
+//! # use jiff::Zoned;
 //! # use std::time::Duration;
 //! # use std::thread::sleep;
 //! # fn job() {
-//! #    println!("Hello, it's {}!", Local::now());
+//! #    println!("Hello, it's {}!", Zoned::now());
 //! # }
 //! # fn greet(name: &str) {
 //! #     println!("Hello, {}!", name);
@@ -41,8 +41,8 @@
 //! every(2)
 //!     .to(8)?
 //!     .seconds()?
-//!     .until(Local::now() + chrono::Duration::seconds(30))?
-//!     .run_one_arg(&mut schedule, greet, "Good-Looking")?;
+//!     .until(Zoned::now() + Duration::from_secs(30))?
+//!     .run_one_arg(&mut schedule, greet, "Cool Person")?;
 //! #   Ok(())
 //! # }
 //! ```
@@ -73,7 +73,7 @@ use callable::{
 pub use error::*;
 pub use job::{every, every_single, Interval, Job, Tag};
 pub use scheduler::Scheduler;
-use time::{Real, Timekeeper, Timestamp, Unit};
+use time::{Clock, Timekeeper, Unit};
 
 #[cfg(feature = "ffi")]
 mod ffi;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! Instantiate a `Scheduler` and schedule jobs:
 //! ```rust
 //! # use skedge::{Scheduler, every, every_single};
-//! # use jiff::Zoned;
+//! # use jiff::{ToSpan, Zoned};
 //! # use std::time::Duration;
 //! # use std::thread::sleep;
 //! # fn job() {
@@ -41,7 +41,7 @@
 //! every(2)
 //!     .to(8)?
 //!     .seconds()?
-//!     .until(Zoned::now() + Duration::from_secs(30))?
+//!     .until(Zoned::now().checked_add(30.seconds())?)?
 //!     .run_one_arg(&mut schedule, greet, "Cool Person")?;
 //! #   Ok(())
 //! # }

--- a/src/time.rs
+++ b/src/time.rs
@@ -89,7 +89,7 @@ pub mod mock {
 	use std::sync::LazyLock;
 
 	pub(crate) static START: LazyLock<Zoned> =
-		LazyLock::new(|| "2024-01-01:22:00:00[America/New_York]".parse().unwrap());
+		LazyLock::new(|| "2024-01-01T07:00:00[America/New_York]".parse().unwrap());
 
 	/// Mock the datetime for predictable results.
 	#[derive(Debug)]
@@ -115,7 +115,7 @@ pub mod mock {
 		}
 
 		fn add_duration(&mut self, duration: impl Into<ZonedArithmetic>) {
-			let _ = self.instant.checked_add(duration);
+			self.instant = self.instant.checked_add(duration).unwrap();
 		}
 	}
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,37 +1,39 @@
 //! For mocking purposes, access to the current time is controlled directed through this struct.
 
-use chrono::{prelude::*, Duration};
+use jiff::{Span, ToSpan, Zoned};
 use std::fmt;
-
-/// Timestamps are in the users local timezone
-pub type Timestamp = DateTime<Local>;
 
 pub(crate) trait Timekeeper: std::fmt::Debug {
 	/// Return the current time
-	fn now(&self) -> Timestamp;
+	fn now(&self) -> Zoned;
 	/// Add a specific duration for testing purposes
 	#[cfg(test)]
-	fn add_duration(&mut self, duration: Duration);
+	fn add_duration(&mut self, duration: impl Into<jiff::ZonedArithmetic>);
 }
 
-impl PartialEq for dyn Timekeeper {
-	fn eq(&self, other: &Self) -> bool {
-		self.now() - other.now() < Duration::milliseconds(10)
-	}
-}
-
-impl Eq for dyn Timekeeper {}
-
-#[derive(Debug, Default, Clone, Copy)]
-pub struct Real;
-
-impl Timekeeper for Real {
-	fn now(&self) -> Timestamp {
-		Local::now()
-	}
+#[derive(Debug, Default)]
+pub(crate) enum Clock {
+	#[default]
+	Real,
 	#[cfg(test)]
-	fn add_duration(&mut self, _duration: Duration) {
-		unreachable!() // unneeded
+	Mock(mock::Mock),
+}
+
+impl Timekeeper for Clock {
+	fn now(&self) -> Zoned {
+		match self {
+			Clock::Real => Zoned::now(),
+			#[cfg(test)]
+			Clock::Mock(mock) => mock.now(),
+		}
+	}
+
+	#[cfg(test)]
+	fn add_duration(&mut self, duration: impl Into<jiff::ZonedArithmetic>) {
+		match self {
+			Clock::Real => unreachable!(),
+			Clock::Mock(mock) => mock.add_duration(duration),
+		}
 	}
 }
 
@@ -48,18 +50,18 @@ pub enum Unit {
 }
 
 impl Unit {
-	/// Get a `chrono::Duration` from an interval based on time unit
-	pub fn duration(self, interval: u32) -> Duration {
+	/// Get a [`jiff::SignedDuration`] from an interval based on time unit.
+	pub fn duration(self, interval: u32) -> Span {
 		use Unit::{Day, Hour, Minute, Month, Second, Week, Year};
 		let interval = i64::from(interval);
 		match self {
-			Second => Duration::seconds(interval),
-			Minute => Duration::minutes(interval),
-			Hour => Duration::hours(interval),
-			Day => Duration::days(interval),
-			Week => Duration::weeks(interval),
-			Month => Duration::weeks(interval * 4),
-			Year => Duration::weeks(interval * 52),
+			Second => interval.seconds(),
+			Minute => interval.minutes(),
+			Hour => interval.hours(),
+			Day => interval.days(),
+			Week => interval.weeks(),
+			Month => interval.months(),
+			Year => interval.years(),
 		}
 	}
 }
@@ -82,40 +84,38 @@ impl fmt::Display for Unit {
 
 #[cfg(test)]
 pub mod mock {
-	use super::{Local, TimeZone, Timekeeper, Timestamp};
-	/// Default starting time
-	pub static START: std::sync::LazyLock<Timestamp> = std::sync::LazyLock::new(|| {
-		Local
-			.with_ymd_and_hms(2021, 1, 1, 12, 0, 0)
-			.single()
-			.expect("valid date")
-	});
+	use super::Timekeeper;
+	use jiff::{Zoned, ZonedArithmetic};
+	use std::sync::LazyLock;
+
+	pub(crate) static START: LazyLock<Zoned> =
+		LazyLock::new(|| "2024-01-01:22:00:00[America/New_York]".parse().unwrap());
 
 	/// Mock the datetime for predictable results.
-	#[derive(Debug, Clone, Copy)]
+	#[derive(Debug)]
 	pub struct Mock {
-		stamp: Timestamp,
+		instant: Zoned,
 	}
 
 	impl Mock {
-		pub fn new(stamp: Timestamp) -> Self {
-			Self { stamp }
+		pub fn new(stamp: Zoned) -> Self {
+			Self { instant: stamp }
 		}
 	}
 
 	impl Default for Mock {
 		fn default() -> Self {
-			Self::new(*START)
+			Self::new(START.clone())
 		}
 	}
 
 	impl Timekeeper for Mock {
-		fn now(&self) -> Timestamp {
-			self.stamp
+		fn now(&self) -> Zoned {
+			self.instant.clone()
 		}
 
-		fn add_duration(&mut self, duration: chrono::Duration) {
-			self.stamp += duration;
+		fn add_duration(&mut self, duration: impl Into<ZonedArithmetic>) {
+			let _ = self.instant.checked_add(duration);
 		}
 	}
 }


### PR DESCRIPTION
In addition to removing `chrono` in favor of `jiff`, this change relicenses the repo to MIT.